### PR TITLE
Add GPS Parser Configuration Class

### DIFF
--- a/tests/test_gps_parser.py
+++ b/tests/test_gps_parser.py
@@ -3,10 +3,10 @@ import pytest
 import tempfile
 import os
 from datetime import datetime
-from unittest.mock import patch, Mock
+from unittest.mock import Mock
 
-from src.utils.gps_parser import GPSParser
-from src.models.course import CourseProfile, GPSPoint, GPSMetadata
+from src.utils.gps_parser import GPSParser, GPSParserConfig
+from src.models.course import CourseProfile, GPSPoint
 
 
 class TestGPSParser:
@@ -231,6 +231,131 @@ class TestGPSParser:
         assert climbs == []
         assert technical == []
         assert elevation_gain == 0.0
+
+    def test_gps_parser_config_default_values(self):
+        """Test GPSParserConfig has correct default values"""
+        config = GPSParserConfig()
+        assert config.min_climb_grade == 3.0
+        assert config.min_climb_distance == 0.5
+        assert config.descent_threshold == -8.0
+        assert config.min_descent_length == 0.2
+        assert config.smoothing_window == 5
+        assert config.quality_penalty_factor == 50.0
+        assert config.descent_continuation_threshold == -3.0
+
+    def test_gps_parser_config_custom_values(self):
+        """Test GPSParserConfig with custom values"""
+        config = GPSParserConfig(
+            min_climb_grade=4.0,
+            min_climb_distance=0.3,
+            descent_threshold=-10.0,
+            min_descent_length=0.15,
+            smoothing_window=3,
+            quality_penalty_factor=75.0,
+        )
+        assert config.min_climb_grade == 4.0
+        assert config.min_climb_distance == 0.3
+        assert config.descent_threshold == -10.0
+        assert config.min_descent_length == 0.15
+        assert config.smoothing_window == 3
+        assert config.quality_penalty_factor == 75.0
+
+    def test_parser_with_config_object(self):
+        """Test GPS parser initialization with config object"""
+        config = GPSParserConfig(
+            min_climb_grade=5.0, min_climb_distance=0.8, smoothing_window=7
+        )
+        parser = GPSParser(config=config)
+
+        assert parser.config.min_climb_grade == 5.0
+        assert parser.config.min_climb_distance == 0.8
+        assert parser.config.smoothing_window == 7
+        # Backward compatibility attributes
+        assert parser.min_climb_grade == 5.0
+        assert parser.min_climb_distance == 0.8
+
+    def test_parser_backward_compatibility(self):
+        """Test GPS parser backward compatibility with old parameters"""
+        parser = GPSParser(min_climb_grade=4.5, min_climb_distance=0.7)
+
+        assert parser.config.min_climb_grade == 4.5
+        assert parser.config.min_climb_distance == 0.7
+        # Should still use default values for other parameters
+        assert parser.config.smoothing_window == 5
+        assert parser.config.descent_threshold == -8.0
+
+    def test_parser_default_config(self):
+        """Test GPS parser uses default config when no parameters provided"""
+        parser = GPSParser()
+
+        assert parser.config.min_climb_grade == 3.0
+        assert parser.config.min_climb_distance == 0.5
+        assert parser.config.smoothing_window == 5
+        assert parser.config.descent_threshold == -8.0
+        assert parser.config.min_descent_length == 0.2
+        assert parser.config.quality_penalty_factor == 50.0
+
+    def test_custom_smoothing_window_in_gradient_calculation(self):
+        """Test that custom smoothing window is used in gradient calculation"""
+        config = GPSParserConfig(smoothing_window=3)
+        parser = GPSParser(config=config)
+
+        gps_points = [
+            GPSPoint(40.0000, -74.0000, 100.0, 0.0),
+            GPSPoint(40.0010, -74.0000, 110.0, 0.069),
+            GPSPoint(40.0020, -74.0000, 120.0, 0.138),
+        ]
+
+        # This should work without error using custom smoothing window
+        parser._calculate_gradients(gps_points)
+        assert gps_points[1].gradient_percent is not None
+        assert gps_points[2].gradient_percent is not None
+
+    def test_custom_quality_penalty_factor(self):
+        """Test custom quality penalty factor in metadata generation"""
+        config = GPSParserConfig(
+            quality_penalty_factor=25.0
+        )  # Half the default penalty
+        parser = GPSParser(config=config)
+
+        # Mock track points with 50% missing elevation
+        track_points = [
+            Mock(elevation=100, latitude=40.0, longitude=-74.0),
+            Mock(elevation=None, latitude=40.1, longitude=-74.1),  # Missing elevation
+        ]
+
+        gps_points = [
+            GPSPoint(40.0, -74.0, 100.0, 0.0),
+            GPSPoint(40.1, -74.1, 0.0, 0.1),
+        ]
+
+        metadata = parser._generate_metadata("test.gpx", gps_points, track_points)
+
+        # With 50% missing elevation and penalty factor 25.0:
+        # quality_score = 100 - (0.5 * 25.0) = 87.5
+        assert metadata.data_quality_score == 87.5
+
+    def test_custom_descent_detection_parameters(self):
+        """Test custom descent threshold and minimum length"""
+        config = GPSParserConfig(
+            descent_threshold=-5.0,  # Less steep threshold
+            min_descent_length=0.1,  # Shorter minimum length
+            descent_continuation_threshold=-2.0,  # Allow gentler continuation
+        )
+        parser = GPSParser(config=config)
+
+        # Create GPS points with a moderate descent that would be detected with custom params
+        gps_points = [
+            GPSPoint(40.0000, -74.0000, 300.0, 0.0, 0.0),
+            GPSPoint(40.0010, -74.0000, 285.0, 0.15, -6.0),  # Moderate descent
+            GPSPoint(40.0020, -74.0000, 280.0, 0.25, -2.5),  # Continue descent
+        ]
+
+        technical_sections = parser._identify_technical_sections(gps_points)
+
+        # Should detect the descent with custom parameters
+        assert len(technical_sections) > 0
+        assert "Steep descent" in technical_sections[0]
 
     @pytest.fixture(autouse=True)
     def cleanup_temp_files(self):


### PR DESCRIPTION
## Summary
Implements issue #3 by creating a configuration class to replace magic numbers in the GPS parser with configurable parameters.

## Changes Made
- ✅ Created `GPSParserConfig` dataclass with all configurable parameters
- ✅ Updated `GPSParser` constructor to accept config parameter (with backward compatibility)
- ✅ Replaced all magic numbers with config values:
  - `min_climb_grade` (default: 3.0%)
  - `min_climb_distance` (default: 0.5 miles) 
  - `descent_threshold` (default: -8.0%)
  - `min_descent_length` (default: 0.2 miles)
  - `smoothing_window` (default: 5 points)
  - `quality_penalty_factor` (default: 50.0)
  - `descent_continuation_threshold` (default: -3.0%) - *newly added*
- ✅ Added comprehensive tests for custom configurations
- ✅ Fixed descent detection logic bug in `_identify_technical_sections` method
- ✅ Cleaned up unused imports and variables
- ✅ Applied code formatting with Black

## Usage Examples

### New preferred approach with config:
```python
from src.utils.gps_parser import GPSParser, GPSParserConfig

# Custom configuration
config = GPSParserConfig(
    min_climb_grade=4.0,
    smoothing_window=7,
    quality_penalty_factor=25.0
)
parser = GPSParser(config=config)
```

### Backward compatible approach:
```python
# Still works for existing code
parser = GPSParser(min_climb_grade=4.0, min_climb_distance=0.3)
```

## Bug Fix
Fixed a logic error in descent detection where the descent length calculation was incorrect, causing some valid descents to not be detected.

## Testing
- All existing tests pass ✅
- Added 8 new test methods covering:
  - Config default values
  - Config custom values  
  - Parser initialization with config
  - Backward compatibility
  - Custom smoothing window behavior
  - Custom quality penalty factor
  - Custom descent detection parameters

## Breaking Changes
None - fully backward compatible with existing code.

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)